### PR TITLE
[Add] Media unit and e2e tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ A robust file upload and media management system built with NestJS, TypeORM, and
 - **TypeORM integration** for database operations
 - **Docker integration** for development environment setup
 - **Static file serving** for easy access to uploaded media
+- **Comprehensive file validation** for security:
+  - File type (MIME) validation
+  - Rejection of executable files (.exe, .dll, .bat, .cmd, .sh, etc.)
+  - File size limits (max 10MB)
+- **Extensive test coverage** for both unit and E2E tests
 
 ## Project Structure
 
@@ -28,6 +33,9 @@ src/
 ├── storage/          # Storage service for file handling
 │   ├── disks/        # Disk storage configurations
 │   ├── services/     # Storage services
+test/
+├── app.e2e-spec.ts   # E2E tests for app endpoints
+├── media.e2e-spec.ts # E2E tests for media operations and file validation
 ```
 
 ## API Endpoints
@@ -117,6 +125,30 @@ Response will include URLs to the original file and different thumbnail sizes:
 }
 ```
 
+## File Validation
+
+The system implements the following security validations for file uploads:
+
+### File Type Validation
+- Whitelist of allowed MIME types:
+  - Images: JPEG, PNG, GIF, WebP, SVG
+  - Documents: PDF, Word, Excel, PowerPoint, TXT, CSV
+  - Audio: MP3, WAV, OGG
+  - Video: MP4, MPEG, WebM, QuickTime
+  - Archives: ZIP, RAR
+
+### Blacklisted File Extensions
+The system rejects potentially dangerous file types, including:
+- Executable files (.exe)
+- DLL files (.dll)
+- Batch scripts (.bat, .cmd)
+- Shell scripts (.sh)
+- System files (.sys, .com)
+- Installation files (.msi, .app, .dmg)
+
+### Size Limits
+- Maximum file size: 10MB
+
 ## Testing
 
 ```bash
@@ -129,6 +161,19 @@ $ npm run test:e2e
 # test coverage
 $ npm run test:cov
 ```
+
+### Test Coverage
+- **Unit tests** cover controller methods, service interactions, and edge cases
+- **E2E tests** cover:
+  - File upload validation (file types, size limits)
+  - CRUD operations for media entities
+  - Error handling scenarios
+
+### Recent Updates (May 2025)
+- Added comprehensive file validation to prevent security vulnerabilities
+- Implemented extensive CRUD test coverage for media operations
+- Fixed path alias resolution issues in Jest configuration for both unit and E2E tests
+- Added E2E tests for file validation ensuring proper rejection of executable files
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -80,6 +80,9 @@
       "**/*.(t|j)s"
     ],
     "coverageDirectory": "../coverage",
-    "testEnvironment": "node"
+    "testEnvironment": "node",
+    "moduleNameMapper": {
+      "^@/(.*)$": "<rootDir>/$1"
+    }
   }
 }

--- a/src/media/media.controller.spec.ts
+++ b/src/media/media.controller.spec.ts
@@ -1,0 +1,224 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { MediaController } from './media.controller';
+import { MediaService } from './media.service';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { CreateMediaDto } from './dto/create-media.dto';
+import { UpdateMediaDto } from './dto/update-media.dto';
+import { Media } from './entities/media.entity';
+
+// Mock file for testing
+const createMockFile = (
+  originalName: string,
+  mimeType: string,
+  size: number,
+): Express.Multer.File => ({
+  fieldname: 'file',
+  originalname: originalName,
+  encoding: '7bit',
+  mimetype: mimeType,
+  size: size,
+  destination: './storage/public/tmp',
+  filename: `${Date.now()}-${originalName}`,
+  path: `./storage/public/tmp/${Date.now()}-${originalName}`,
+  buffer: Buffer.from('test file content'),
+  stream: null as any,
+});
+
+describe('MediaController', () => {
+  let controller: MediaController;
+  let service: MediaService;
+
+  // Mock media service to avoid database interactions during tests
+  const mockMediaService = {
+    create: jest.fn(),
+    findAll: jest.fn(),
+    findOne: jest.fn(),
+    update: jest.fn(),
+    remove: jest.fn(),
+    getMediaUrl: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [MediaController],
+      providers: [
+        {
+          provide: MediaService,
+          useValue: mockMediaService,
+        },
+      ],
+    }).compile();
+
+    controller = module.get<MediaController>(MediaController);
+    service = module.get<MediaService>(MediaService);
+
+    // Reset all mock implementations before each test
+    jest.clearAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  describe('create', () => {
+    it('should create a new media item with valid file', async () => {
+      // Setup mock file
+      const mockFile = createMockFile('test.jpg', 'image/jpeg', 1024 * 1024);
+      const createMediaDto: CreateMediaDto = { collection: 'test-collection' };
+      
+      // Setup mock return value
+      const mockMedia = {
+        id: 1,
+        fileName: 'test.jpg',
+        mimeType: 'image/jpeg',
+        size: 1024 * 1024,
+        collection: 'test-collection',
+        uuid: '550e8400-e29b-41d4-a716-446655440000',
+        created_at: new Date(),
+        updated_at: new Date(),
+      } as Media;
+      
+      mockMediaService.create.mockResolvedValue(mockMedia);
+      mockMediaService.getMediaUrl.mockReturnValue('/storage/1/test.jpg');
+      
+      // Make request
+      const result = await controller.create(createMediaDto, mockFile);
+      
+      // Assertions
+      expect(service.create).toHaveBeenCalledWith(createMediaDto, mockFile);
+      expect(result).toHaveProperty('id', 1);
+      expect(result).toHaveProperty('urls');
+      expect(result.urls).toHaveProperty('original');
+      expect(result.urls).toHaveProperty('thumb');
+      expect(result.urls).toHaveProperty('small');
+      expect(result.urls).toHaveProperty('medium');
+      expect(result.urls).toHaveProperty('large');
+    });
+
+    // Note: File validation tests will be handled by the middleware
+    // but we can still test the endpoint behavior with different files
+  });
+
+  describe('findAll', () => {
+    it('should return an array of media items with URLs', async () => {
+      // Mock return value
+      const mockMediaItems = [
+        {
+          id: 1,
+          fileName: 'test1.jpg',
+          mimeType: 'image/jpeg',
+          size: 1024 * 1024,
+          collection: 'collection1',
+          uuid: '550e8400-e29b-41d4-a716-446655440001',
+          created_at: new Date(),
+          updated_at: new Date(),
+        },
+        {
+          id: 2,
+          fileName: 'test2.png',
+          mimeType: 'image/png',
+          size: 2048 * 1024,
+          collection: 'collection2',
+          uuid: '550e8400-e29b-41d4-a716-446655440002',
+          created_at: new Date(),
+          updated_at: new Date(),
+        },
+      ] as Media[];
+
+      mockMediaService.findAll.mockResolvedValue(mockMediaItems);
+      mockMediaService.getMediaUrl.mockImplementation((media, conversion) => {
+        return `/storage/${media.id}/${conversion ? `${conversion}_` : ''}${media.fileName}`;
+      });
+
+      // Call the controller method
+      const result = await controller.findAll();
+
+      // Assertions
+      expect(service.findAll).toHaveBeenCalled();
+      expect(result).toHaveLength(2);
+      expect(result[0]).toHaveProperty('urls');
+      expect(result[0].urls.original).toBe('/storage/1/test1.jpg');
+      expect(result[1].urls.original).toBe('/storage/2/test2.png');
+    });
+  });
+
+  describe('findOne', () => {
+    it('should return a single media item with URLs', async () => {
+      // Mock return value
+      const mockMedia = {
+        id: 1,
+        fileName: 'test.jpg',
+        mimeType: 'image/jpeg',
+        size: 1024 * 1024,
+        collection: 'test-collection',
+        uuid: '550e8400-e29b-41d4-a716-446655440000',
+        created_at: new Date(),
+        updated_at: new Date(),
+      } as Media;
+
+      mockMediaService.findOne.mockResolvedValue(mockMedia);
+      mockMediaService.getMediaUrl.mockImplementation((media, conversion) => {
+        return `/storage/${media.id}/${conversion ? `${conversion}_` : ''}${media.fileName}`;
+      });
+
+      // Call the controller method
+      const result = await controller.findOne('1');
+
+      // Assertions
+      expect(service.findOne).toHaveBeenCalledWith(1);
+      expect(result).toHaveProperty('id', 1);
+      expect(result.urls.original).toBe('/storage/1/test.jpg');
+      expect(result.urls.thumb).toBe('/storage/1/thumb_test.jpg');
+    });
+
+    it('should throw NotFoundException when media is not found', async () => {
+      // Setup mock to return null (not found)
+      mockMediaService.findOne.mockResolvedValue(null);
+
+      // Assertions
+      await expect(controller.findOne('999')).rejects.toThrow(NotFoundException);
+      expect(service.findOne).toHaveBeenCalledWith(999);
+    });
+  });
+
+  describe('update', () => {
+    it('should update a media item', async () => {
+      // Setup
+      const updateMediaDto: UpdateMediaDto = { fileName: 'updated.jpg' };
+      const mockUpdatedMedia = {
+        id: 1,
+        fileName: 'updated.jpg',
+        mimeType: 'image/jpeg',
+        size: 1024 * 1024,
+        collection: 'test-collection',
+        uuid: '550e8400-e29b-41d4-a716-446655440000',
+        created_at: new Date(),
+        updated_at: new Date(),
+      } as Media;
+
+      mockMediaService.update.mockResolvedValue(mockUpdatedMedia);
+
+      // Call the controller method
+      const result = await controller.update('1', updateMediaDto);
+
+      // Assertions
+      expect(service.update).toHaveBeenCalledWith(1, updateMediaDto);
+      expect(result).toEqual(mockUpdatedMedia);
+    });
+  });
+
+  describe('remove', () => {
+    it('should delete a media item', async () => {
+      // Setup
+      const mockResult = { success: true, message: 'Media deleted successfully' };
+      mockMediaService.remove.mockResolvedValue(mockResult);
+
+      // Call the controller method
+      const result = await controller.remove('1');
+
+      // Assertions
+      expect(service.remove).toHaveBeenCalledWith(1);
+      expect(result).toEqual(mockResult);
+    });
+  });
+});

--- a/src/storage/disks/local.storage.ts
+++ b/src/storage/disks/local.storage.ts
@@ -1,8 +1,59 @@
 import { diskStorage } from 'multer';
 import { extname } from 'path';
 import { v4 as uuidv4 } from 'uuid';
+import { BadRequestException } from '@nestjs/common';
+
+// Disallowed file extensions (binary/executable files)
+const DISALLOWED_FILE_EXTENSIONS = [
+  '.exe', '.dll', '.bat', '.cmd', '.sh', '.bin', 
+  '.msi', '.app', '.dmg', '.sys', '.com'
+];
+
+// Allowed MIME types
+const ALLOWED_MIME_TYPES = [
+  // Images
+  'image/jpeg', 'image/png', 'image/gif', 'image/webp', 'image/svg+xml',
+  // Documents
+  'application/pdf', 'application/msword', 
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+  'application/vnd.ms-excel',
+  'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  'application/vnd.ms-powerpoint',
+  'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+  'text/plain', 'text/csv',
+  // Audio
+  'audio/mpeg', 'audio/wav', 'audio/ogg',
+  // Video
+  'video/mp4', 'video/mpeg', 'video/webm', 'video/quicktime',
+  // Archives (if needed)
+  'application/zip', 'application/x-rar-compressed'
+];
 
 export const localStorageConfig = {
+  limits: {
+    fileSize: 10 * 1024 * 1024, // 10MB
+  },
+  fileFilter: (req, file, callback) => {
+    // Check file extension
+    const ext = extname(file.originalname).toLowerCase();
+    if (DISALLOWED_FILE_EXTENSIONS.includes(ext)) {
+      return callback(
+        new BadRequestException(`File type ${ext} is not allowed for security reasons`),
+        false
+      );
+    }
+
+    // Check mime type
+    if (!ALLOWED_MIME_TYPES.includes(file.mimetype)) {
+      return callback(
+        new BadRequestException(`File type ${file.mimetype} is not allowed`),
+        false
+      );
+    }
+
+    // File is valid
+    callback(null, true);
+  },
   storage: diskStorage({
     destination: './storage/public/tmp',
     filename: (req, file, callback) => {
@@ -11,7 +62,4 @@ export const localStorageConfig = {
       callback(null, `${uniqueSuffix}${ext}`);
     },
   }),
-  limits: {
-    fileSize: 10 * 1024 * 1024, // 10MB
-  },
 };

--- a/test/jest-e2e.json
+++ b/test/jest-e2e.json
@@ -5,5 +5,8 @@
   "testRegex": ".e2e-spec.ts$",
   "transform": {
     "^.+\\.(t|j)s$": "ts-jest"
+  },
+  "moduleNameMapper": {
+    "^@/(.*)$": "<rootDir>/../src/$1"
   }
 }

--- a/test/media.e2e-spec.ts
+++ b/test/media.e2e-spec.ts
@@ -1,0 +1,323 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import * as request from 'supertest';
+import { AppModule } from '../src/app.module';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+
+describe('Media Upload E2E Tests', () => {
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  /**
+   * Helper function to create test files of different types and sizes
+   */
+  const createTestFile = (
+    fileName: string,
+    content: string | Buffer,
+  ): string => {
+    const filePath = path.join(os.tmpdir(), fileName);
+    fs.writeFileSync(filePath, content);
+    return filePath;
+  };
+
+  describe('/media (POST) - File Upload Validation', () => {
+    it('should accept a valid image file', async () => {
+      // Create a small JPEG file
+      const validImagePath = createTestFile(
+        'valid-image.jpg',
+        Buffer.from(
+          '/9j/4AAQSkZJRgABAQEAYABgAAD/2wBDAAIBAQIBAQICAgICAgICAwUDAwMDAwYEBAMFBwYHBwcGBwcICQsJCAgKCAcHCg0KCgsMDAwMBwkODw0MDgsMDAz/2wBDAQICAgMDAwYDAwYMCAcIDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAz/wAARCAABAAEDASIAAhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSExBhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD9/KKKKAP/2Q==',
+          'base64'
+        )
+      );
+
+      // Make the request
+      return request(app.getHttpServer())
+        .post('/media')
+        .attach('file', validImagePath)
+        .field('collection', 'test-images')
+        .expect(201)
+        .then((response) => {
+          expect(response.body).toHaveProperty('id');
+          expect(response.body).toHaveProperty('urls');
+          expect(response.body.mimeType).toBe('image/jpeg');
+          // Clean up test file
+          fs.unlinkSync(validImagePath);
+        });
+    });
+
+    it('should accept a valid PDF file', async () => {
+      // Create a simple PDF file
+      // This is a minimal valid PDF content
+      const pdfContent = '%PDF-1.4\n1 0 obj<</Type/Catalog/Pages 2 0 R>>endobj\n2 0 obj<</Type/Pages/Kids[3 0 R]/Count 1>>endobj\n3 0 obj<</Type/Page/MediaBox[0 0 3 3]>>endobj\nxref\n0 4\n0000000000 65535 f\n0000000009 00000 n\n0000000052 00000 n\n0000000101 00000 n\ntrailer<</Size 4/Root 1 0 R>>\nstartxref\n149\n%%EOF';
+      const validPdfPath = createTestFile('valid-doc.pdf', pdfContent);
+
+      // Make the request
+      return request(app.getHttpServer())
+        .post('/media')
+        .attach('file', validPdfPath)
+        .field('collection', 'test-documents')
+        .expect(201)
+        .then((response) => {
+          expect(response.body).toHaveProperty('id');
+          expect(response.body).toHaveProperty('urls');
+          expect(response.body.mimeType).toBe('application/pdf');
+          // Clean up test file
+          fs.unlinkSync(validPdfPath);
+        });
+    });
+
+    it('should reject executable files (.exe)', async () => {
+      // Create a fake .exe file
+      // Just a binary content with MZ header
+      const exeContent = Buffer.from('4D5A900003000000040000000FFFF0000B800000000000000400000000000000000000000000000000000000000000000000000000000000000000000', 'hex');
+      const exePath = createTestFile('malicious.exe', exeContent);
+
+      // Make the request
+      return request(app.getHttpServer())
+        .post('/media')
+        .attach('file', exePath)
+        .field('collection', 'test-documents')
+        .expect(400)
+        .then((response) => {
+          expect(response.body.message).toContain('not allowed for security reasons');
+          // Clean up test file
+          fs.unlinkSync(exePath);
+        });
+    });
+
+    it('should reject DLL files', async () => {
+      // Create a fake .dll file
+      const dllPath = createTestFile('library.dll', 'fake dll content');
+
+      // Make the request
+      return request(app.getHttpServer())
+        .post('/media')
+        .attach('file', dllPath)
+        .field('collection', 'test-documents')
+        .expect(400)
+        .then((response) => {
+          expect(response.body.message).toContain('not allowed for security reasons');
+          // Clean up test file
+          fs.unlinkSync(dllPath);
+        });
+    });
+
+    it('should reject batch files', async () => {
+      // Create a fake .bat file
+      const batPath = createTestFile('script.bat', 'echo "This is a batch file"');
+
+      // Make the request
+      return request(app.getHttpServer())
+        .post('/media')
+        .attach('file', batPath)
+        .field('collection', 'test-documents')
+        .expect(400)
+        .then((response) => {
+          expect(response.body.message).toContain('not allowed for security reasons');
+          // Clean up test file
+          fs.unlinkSync(batPath);
+        });
+    });
+
+    it('should reject shell script files', async () => {
+      // Create a fake .sh file
+      const shPath = createTestFile('script.sh', '#!/bin/bash\necho "This is a shell script"');
+
+      // Make the request
+      return request(app.getHttpServer())
+        .post('/media')
+        .attach('file', shPath)
+        .field('collection', 'test-documents')
+        .expect(400)
+        .then((response) => {
+          expect(response.body.message).toContain('not allowed for security reasons');
+          // Clean up test file
+          fs.unlinkSync(shPath);
+        });
+    });
+
+    it('should reject files with disallowed MIME types', async () => {
+      // Create a file with an application/x-msdownload MIME type (typical for executables)
+      const maliciousPath = createTestFile('malicious.bin', Buffer.from('fake binary content'));
+
+      // Make the request with a manipulated mime type
+      return request(app.getHttpServer())
+        .post('/media')
+        .attach('file', maliciousPath)
+        .set('Content-Type', 'multipart/form-data; boundary=X')
+        .field('collection', 'test-documents')
+        .expect(400)
+        .then(() => {
+          // Clean up test file
+          fs.unlinkSync(maliciousPath);
+        });
+    });
+
+    it('should reject files larger than 10MB', async () => {
+      // Create a large file (just over 10MB)
+      const largeFilePath = createTestFile(
+        'large-file.txt', 
+        Buffer.alloc(10 * 1024 * 1024 + 1, 'a')
+      );
+
+      // Make the request
+      return request(app.getHttpServer())
+        .post('/media')
+        .attach('file', largeFilePath)
+        .field('collection', 'test-documents')
+        .expect(413) // Payload Too Large
+        .then(() => {
+          // Clean up test file
+          fs.unlinkSync(largeFilePath);
+        });
+    });
+  });
+
+  describe('/media (GET) - Retrieve Media', () => {
+    // This assumes there's at least one media item in the database
+    it('should return a list of media items', () => {
+      return request(app.getHttpServer())
+        .get('/media')
+        .expect(200)
+        .then((response) => {
+          expect(Array.isArray(response.body)).toBe(true);
+        });
+    });
+  });
+
+  describe('/media/:id (GET) - Get Media by ID', () => {
+    // First create a media item, then retrieve it by ID
+    let createdMediaId: number;
+
+    beforeAll(async () => {
+      // Create a test image
+      const imagePath = createTestFile(
+        'test-retrieve.jpg',
+        Buffer.from(
+          '/9j/4AAQSkZJRgABAQEAYABgAAD/2wBDAAIBAQIBAQICAgICAgICAwUDAwMDAwYEBAMFBwYHBwcGBwcICQsJCAgKCAcHCg0KCgsMDAwMBwkODw0MDgsMDAz/2wBDAQICAgMDAwYDAwYMCAcIDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAz/wAARCAABAAEDASIAAhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSExBhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD9/KKKKAP/2Q==',
+          'base64'
+        )
+      );
+
+      // Upload the image to get an ID
+      const response = await request(app.getHttpServer())
+        .post('/media')
+        .attach('file', imagePath)
+        .field('collection', 'test-retrieve')
+        .expect(201);
+
+      createdMediaId = response.body.id;
+      fs.unlinkSync(imagePath);
+    });
+
+    it('should retrieve a media item by ID', () => {
+      return request(app.getHttpServer())
+        .get(`/media/${createdMediaId}`)
+        .expect(200)
+        .then((response) => {
+          expect(response.body).toHaveProperty('id', createdMediaId);
+          expect(response.body).toHaveProperty('urls');
+          expect(response.body).toHaveProperty('collection', 'test-retrieve');
+        });
+    });
+
+    it('should return 404 for non-existent media ID', () => {
+      return request(app.getHttpServer())
+        .get(`/media/99999`)
+        .expect(404);
+    });
+  });
+
+  describe('/media/:id (PATCH) - Update Media', () => {
+    // First create a media item, then update it
+    let createdMediaId: number;
+
+    beforeAll(async () => {
+      // Create a test image
+      const imagePath = createTestFile(
+        'test-update.jpg',
+        Buffer.from(
+          '/9j/4AAQSkZJRgABAQEAYABgAAD/2wBDAAIBAQIBAQICAgICAgICAwUDAwMDAwYEBAMFBwYHBwcGBwcICQsJCAgKCAcHCg0KCgsMDAwMBwkODw0MDgsMDAz/2wBDAQICAgMDAwYDAwYMCAcIDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAz/wAARCAABAAEDASIAAhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSExBhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD9/KKKKAP/2Q==',
+          'base64'
+        )
+      );
+
+      // Upload the image to get an ID
+      const response = await request(app.getHttpServer())
+        .post('/media')
+        .attach('file', imagePath)
+        .field('collection', 'test-update')
+        .expect(201);
+
+      createdMediaId = response.body.id;
+      fs.unlinkSync(imagePath);
+    });
+
+    it('should update a media item', () => {
+      return request(app.getHttpServer())
+        .patch(`/media/${createdMediaId}`)
+        .send({ collection: 'updated-collection' })
+        .expect(200)
+        .then((response) => {
+          expect(response.body).toHaveProperty('id', createdMediaId);
+          expect(response.body).toHaveProperty('collection', 'updated-collection');
+        });
+    });
+  });
+
+  describe('/media/:id (DELETE) - Delete Media', () => {
+    // First create a media item, then delete it
+    let createdMediaId: number;
+
+    beforeAll(async () => {
+      // Create a test image
+      const imagePath = createTestFile(
+        'test-delete.jpg',
+        Buffer.from(
+          '/9j/4AAQSkZJRgABAQEAYABgAAD/2wBDAAIBAQIBAQICAgICAgICAwUDAwMDAwYEBAMFBwYHBwcGBwcICQsJCAgKCAcHCg0KCgsMDAwMBwkODw0MDgsMDAz/2wBDAQICAgMDAwYDAwYMCAcIDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAz/wAARCAABAAEDASIAAhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSExBhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD9/KKKKAP/2Q==',
+          'base64'
+        )
+      );
+
+      // Upload the image to get an ID
+      const response = await request(app.getHttpServer())
+        .post('/media')
+        .attach('file', imagePath)
+        .field('collection', 'test-delete')
+        .expect(201);
+
+      createdMediaId = response.body.id;
+      fs.unlinkSync(imagePath);
+    });
+
+    it('should delete a media item', () => {
+      return request(app.getHttpServer())
+        .delete(`/media/${createdMediaId}`)
+        .expect(200)
+        .then((response) => {
+          expect(response.body).toHaveProperty('success', true);
+          expect(response.body).toHaveProperty('message', 'Media deleted successfully');
+          
+          // Verify it's actually gone
+          return request(app.getHttpServer())
+            .get(`/media/${createdMediaId}`)
+            .expect(404);
+        });
+    });
+  });
+});


### PR DESCRIPTION
This pull request enhances the file upload and media management system by introducing comprehensive file validation, improving test coverage, and adding Jest configuration updates. Key changes include implementing strict file validation to enhance security, expanding unit and E2E test coverage, and improving path alias resolution in Jest for better maintainability.

### File Validation Enhancements:
* [`src/storage/disks/local.storage.ts`](diffhunk://#diff-48c17c5e5748c61511a7d3c25d0d4ce0d3b78ca4acddc1591e8e3f4e1bc3da84R4-R56): Added validation for file uploads to enforce a whitelist of allowed MIME types, reject disallowed file extensions (e.g., `.exe`, `.dll`), and enforce a maximum file size of 10MB. [[1]](diffhunk://#diff-48c17c5e5748c61511a7d3c25d0d4ce0d3b78ca4acddc1591e8e3f4e1bc3da84R4-R56) [[2]](diffhunk://#diff-48c17c5e5748c61511a7d3c25d0d4ce0d3b78ca4acddc1591e8e3f4e1bc3da84L14-L16)
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R128-R151): Documented the new file validation rules, including allowed MIME types, blacklisted file extensions, and size limits.

### Test Coverage Improvements:
* [`src/media/media.controller.spec.ts`](diffhunk://#diff-c2b91011b891dec239c1470da930f6a9800c0e6a6228caea7dd2cf44d4f8323cR1-R224): Added unit tests for `MediaController` to validate file uploads, CRUD operations, and error handling scenarios.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R165-R177): Updated the testing section to reflect the expanded unit and E2E test coverage, including file validation and CRUD operations.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R36-R38): Added entries for E2E test files (`app.e2e-spec.ts`, `media.e2e-spec.ts`) in the project structure documentation.

### Jest Configuration Updates:
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L83-R86): Added `moduleNameMapper` to support path alias resolution for cleaner imports in tests.
* [`test/jest-e2e.json`](diffhunk://#diff-7f0c2ea6142234d2f6988ec1469ed8e1febda2e739cb1cbd3ae688bf683c95b1R8-R10): Updated Jest E2E configuration with `moduleNameMapper` for consistent alias resolution across test environments.