### PR TITLE
Add/pagination

### DIFF
--- a/src/media/dto/pagination.dto.ts
+++ b/src/media/dto/pagination.dto.ts
@@ -1,0 +1,18 @@
+import { IsOptional, Min, IsInt } from 'class-validator';
+import { Transform, Type } from 'class-transformer';
+
+export class PaginationDto {
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  @Type(() => Number)
+  @Transform(({ value }) => parseInt(value, 10))
+  page?: number = 1;
+
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  @Type(() => Number)
+  @Transform(({ value }) => parseInt(value, 10))
+  limit?: number = 10;
+}

--- a/src/media/media.controller.ts
+++ b/src/media/media.controller.ts
@@ -9,12 +9,14 @@ import {
   UseInterceptors,
   UploadedFile,
   NotFoundException,
+  Query,
 } from '@nestjs/common';
 import { MediaService } from './media.service';
 import { CreateMediaDto } from './dto/create-media.dto';
 import { UpdateMediaDto } from './dto/update-media.dto';
 import { FileInterceptor } from '@nestjs/platform-express';
 import { localStorageConfig } from '../storage/disks/local.storage';
+import { PaginationDto } from './dto/pagination.dto';
 
 @Controller('api/v1/media')
 export class MediaController {
@@ -42,11 +44,14 @@ export class MediaController {
   }
 
   @Get()
-  async findAll() {
-    const media = await this.mediaService.findAll();
+  async findAll(@Query() paginationDto: PaginationDto) {
+    // Use default values if not provided
+    const page = paginationDto.page || 1;
+    const limit = paginationDto.limit || 10;
+    const result = await this.mediaService.findAll(page, limit);
     
     // Add URLs to each media item
-    return media.map(item => ({
+    const mediaWithUrls = result.data.map(item => ({
       ...item,
       urls: {
         original: this.mediaService.getMediaUrl(item),
@@ -56,6 +61,17 @@ export class MediaController {
         large: this.mediaService.getMediaUrl(item, 'large'),
       }
     }));
+    
+    return {
+      data: mediaWithUrls,
+      meta: result.meta,
+      links: {
+        first: `api/v1/media?page=1&limit=${limit}`,
+        previous: result.meta.hasPreviousPage ? `api/v1/media?page=${page - 1}&limit=${limit}` : null,
+        next: result.meta.hasNextPage ? `api/v1/media?page=${page + 1}&limit=${limit}` : null,
+        last: `api/v1/media?page=${result.meta.lastPage}&limit=${limit}`
+      }
+    };
   }
 
   @Get(':id')

--- a/src/media/media.service.ts
+++ b/src/media/media.service.ts
@@ -43,8 +43,30 @@ export class MediaService {
     return savedMedia;
   }
 
-  findAll() {
-    return this.mediaRepo.find();
+  async findAll(page: number = 1, limit: number = 10) {
+    const skip = (page - 1) * limit;
+    
+    const [items, total] = await this.mediaRepo.findAndCount({
+      skip,
+      take: limit,
+      order: {
+        id: 'DESC' // Most recent first
+      }
+    });
+
+    const lastPage = Math.ceil(total / limit);
+    
+    return {
+      data: items,
+      meta: {
+        total,
+        page,
+        limit,
+        lastPage,
+        hasNextPage: page < lastPage,
+        hasPreviousPage: page > 1
+      }
+    };
   }
 
   async findOne(id: number) {


### PR DESCRIPTION
This pull request introduces pagination functionality to the media module by adding a `PaginationDto` and updating the `MediaController` and `MediaService` to support paginated responses. The changes ensure that media items can be retrieved in pages, with metadata and navigation links included in the response.

### Pagination Feature Implementation:

* **Addition of `PaginationDto`:** Introduced a new `PaginationDto` class in `src/media/dto/pagination.dto.ts` to handle pagination parameters (`page` and `limit`) with validation and transformation. Default values are set to `page = 1` and `limit = 10`.

* **Controller Updates for Pagination:**
  - Updated `MediaController` to accept `PaginationDto` via the `@Query()` decorator in the `findAll` method. The method now retrieves paginated data from the service and includes metadata (`total`, `page`, `limit`, etc.) and navigation links (`first`, `previous`, `next`, `last`) in the response. [[1]](diffhunk://#diff-efa9df19e1f3edb344210eb9be1f17a3845c521d625a56a1abd772c893e40422L45-R54) [[2]](diffhunk://#diff-efa9df19e1f3edb344210eb9be1f17a3845c521d625a56a1abd772c893e40422R64-R74)
  - Imported `PaginationDto` into `MediaController` to enable its usage.

* **Service Updates for Pagination:**
  - Modified `MediaService`'s `findAll` method to support pagination using `page` and `limit` parameters. The method calculates `skip` for offset-based pagination, retrieves data using `findAndCount`, and returns both the data and metadata (e.g., total items, current page, last page, etc.).